### PR TITLE
[rpm] sonar.properties should not be overwritten on package upgrade

### DIFF
--- a/rpm/SPECS/sonar.spec
+++ b/rpm/SPECS/sonar.spec
@@ -75,7 +75,7 @@ rm -rf %{buildroot}
 %files
 %defattr(0644,sonar,sonar,0755)
 /opt/sonar
-%config /opt/sonar/conf/sonar.properties
+%config(noreplace) /opt/sonar/conf/sonar.properties
 
 %attr(0755,sonar,sonar) /opt/sonar/bin/linux-x86-32/sonar.sh
 %attr(0755,sonar,sonar) /opt/sonar/bin/linux-x86-32/wrapper


### PR DESCRIPTION
Use `%config(noreplace)` for `/opt/sonar/conf/sonar.properties` to protect local modifications. 

More information:
* [RPM, %config, and (noreplace)](http://www-uxsup.csx.cam.ac.uk/~jw35/docs/rpm_config.html)
* [Marking files as documentation or configuration files](http://www-uxsup.csx.cam.ac.uk/~jw35/docs/rpm_config.html)
