### PR TITLE
Fixed deb/tmp removal

### DIFF
--- a/deb/build.sh
+++ b/deb/build.sh
@@ -14,7 +14,7 @@ fi
 VER=$1
 
 # prepare fresh directories
-rm -rv tmp/
+[ -d tmp ] && rm -rv tmp/
 mkdir -p tmp/DEBIAN/
 
 # changelog


### PR DESCRIPTION
Build-deb.sh fails if the directory deb/tmp doesn't exist.